### PR TITLE
Use getargspec only with Python 2, fix for Kodi 20

### DIFF
--- a/lib/cherrypy/_cpdispatch.py
+++ b/lib/cherrypy/_cpdispatch.py
@@ -206,12 +206,14 @@ except ImportError:
     def test_callable_spec(callable, args, kwargs):  # noqa: F811
         return None
 else:
-    getargspec = inspect.getargspec
     # Python 3 requires using getfullargspec if
     # keyword-only arguments are present
     if hasattr(inspect, 'getfullargspec'):
         def getargspec(callable):
             return inspect.getfullargspec(callable)[:4]
+    # Use getargspec with Python 2
+    else:
+        getargspec = inspect.getargspec
 
 
 class LateParamPageHandler(PageHandler):


### PR DESCRIPTION
Found small error in "compatibility" code: it used to work for python 3 since `getargspec` still existed until Python 3.11.
But Kodi 20 uses Python 3.11 - thus addon does not work anymore:
```
File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/script.module.cherrypy/lib/cherrypy/_cpdispatch.py", line 209, in <module>
  getargspec = inspect.getargspec
               ^^^^^^^^^^^^^^^^^^
AttributeError: module 'inspect' has no attribute 'getargspec'
```

Fix tested on python 2 and 3.

https://docs.python.org/3/whatsnew/3.11.html#removed

https://docs.python.org/2/library/inspect.html#inspect.getargspec
https://docs.python.org/3/library/inspect.html#inspect.getfullargspec